### PR TITLE
Enable ModernCrypto default

### DIFF
--- a/lib/ciphersweet.js
+++ b/lib/ciphersweet.js
@@ -20,10 +20,13 @@ module.exports = class CipherSweet
      * @param {module.KeyProvider} keyProvider
      * @param {module.Backend|null} backend
      */
-    constructor(keyProvider, backend = null)
+    constructor(keyProvider, backend = new ModernCrypto())
     {
         if (!(keyProvider instanceof KeyProvider)) {
             throw new TypeError("Argument 1 must be an instance of keyprovider");
+        }
+        if (!(backend instanceof Backend)) {
+            throw new TypeError("Argument 2 must be an instance of backend");
         }
         this.keyProvider = keyProvider;
         if (!backend) {

--- a/lib/ciphersweet.js
+++ b/lib/ciphersweet.js
@@ -25,9 +25,6 @@ module.exports = class CipherSweet
         if (!(keyProvider instanceof KeyProvider)) {
             throw new TypeError("Argument 1 must be an instance of keyprovider");
         }
-        if (!(backend instanceof Backend)) {
-            throw new TypeError("Argument 2 must be an instance of backend");
-        }
         this.keyProvider = keyProvider;
         if (!backend) {
             backend = new ModernCrypto();


### PR DESCRIPTION
The check in the constructor here makes the code behave differently from the documentation. Passing in no backend should be valid and should default to `new ModernCrypto()`.