### PR TITLE
Allow Index customization in Typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,11 +55,22 @@ declare module "ciphersweet-js" {
         ): Promise<FieldStorageTuple>;
     }
 
+    export interface ModernCryptoHashConfig {
+        opslimit: number;
+        memlimit: number;
+    }
+    
+    export interface FIPSCryptoHashConfig {
+        iterations: number;
+    }
+
     export class BlindIndex {
         constructor(
             name: string,
             transforms: Transform[],
-            bloomFilterSizeInBits: number
+            bloomFilterSizeInBits?: number,
+            fastHash?: boolean,
+            config?: ModernCryptoHashConfig | FIPSCryptoHashConfig
         );
     }
 
@@ -67,8 +78,9 @@ declare module "ciphersweet-js" {
         constructor(
             indexName: string,
             fieldNames: string[],
-            bloomFilterSizeInBits: number,
-            fastHash: boolean
+            bloomFilterSizeInBits?: number,
+            fastHash?: boolean,
+            config?: ModernCryptoHashConfig | FIPSCryptoHashConfig
         );
         public addTransform(
             fieldName: string,
@@ -95,8 +107,9 @@ declare module "ciphersweet-js" {
         public createCompoundIndex(
             indexName: string,
             fieldNames: string[],
-            bloomFilterSizeInBits: number,
-            fastHash: boolean
+            bloomFilterSizeInBits?: number,
+            fastHash?: boolean,
+            config?: ModernCryptoHashConfig | FIPSCryptoHashConfig
         ): CompoundIndex;
 
         public prepareRowForStorage(row: any): Promise<RowStorageTuple>;
@@ -152,8 +165,9 @@ declare module "ciphersweet-js" {
             tableName: string,
             indexName: string,
             fieldNames: string[],
-            bloomFilterSizeInBits: number,
-            fastHash: boolean
+            bloomFilterSizeInBits?: number,
+            fastHash?: boolean,
+            config?: ModernCryptoHashConfig | FIPSCryptoHashConfig
         ): CompoundIndex;
 
         public prepareForStorage(input: any): Promise<MultiRowStorageTuple>;

--- a/lib/blindindex.js
+++ b/lib/blindindex.js
@@ -17,7 +17,7 @@ module.exports = class BlindIndex
      * @param {boolean} fastHash
      * @param {object|Array} hashConfig
      */
-    constructor(name, transformations = [], filterBits = 256, fastHash = false, hashConfig = [])
+    constructor(name, transformations = [], filterBits = 256, fastHash = false, hashConfig = {})
     {
         this.name = name;
         this.transformations = transformations;


### PR DESCRIPTION
We need to use the fast hash for our blind index on a Typescript project, but it's not exposed in the current typings. I've added that along with the ability to pass config to all methods that create indexes. This PR also fixes a typo in the BlindIndex constructor signature.